### PR TITLE
Add caching rules for immutable files in web.config

### DIFF
--- a/browser/web.config
+++ b/browser/web.config
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+
 <system.webServer>
     <httpCompression directory="%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files">
         <scheme name="gzip" dll="%Windir%\system32\inetsrv\gzip.dll" />
@@ -27,12 +28,8 @@
           <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
           <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
         </conditions>
-        <action type="Rewrite" url="/angular-demos-dv/" />
+        <action type="Rewrite" url="./index.html" />
       </rule>
-      <rule name="Angular Root Redirect" enabled="true" stopProcessing="true">
-        <match url="^/?$" />
-        <action type="Redirect" url="/products/ignite-ui-angular/getting-started" redirectType="Permanent" />
-    </rule>
     </rules>
     <outboundRules>
       <rule name="Cache immutable files" preCondition="IsImmutable">
@@ -73,13 +70,13 @@
           <add name="X-XSS-Protection" value="0" />
       </customHeaders>
   </httpProtocol>
-</system.webServer>
-<location path="index.html">
-  <system.webServer>
-    <staticContent>
-      <!-- Short-lived cache for index.html -->
-      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="0.00:05:00" cacheControlCustom="public" />
-    </staticContent>
   </system.webServer>
-</location>
+	<location path="index.html">
+	  <system.webServer>
+	    <staticContent>
+	      <!-- Short-lived cache for index.html -->
+	      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="0.00:05:00" cacheControlCustom="public" />
+	    </staticContent>
+	  </system.webServer>
+	</location>
 </configuration>

--- a/browser/web.config
+++ b/browser/web.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-
 <system.webServer>
     <httpCompression directory="%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files">
         <scheme name="gzip" dll="%Windir%\system32\inetsrv\gzip.dll" />
@@ -28,8 +27,12 @@
           <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
           <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
         </conditions>
-        <action type="Rewrite" url="./index.html" />
+        <action type="Rewrite" url="/angular-demos-dv/" />
       </rule>
+      <rule name="Angular Root Redirect" enabled="true" stopProcessing="true">
+        <match url="^/?$" />
+        <action type="Redirect" url="/products/ignite-ui-angular/getting-started" redirectType="Permanent" />
+    </rule>
     </rules>
     <outboundRules>
       <rule name="Cache immutable files" preCondition="IsImmutable">
@@ -70,13 +73,13 @@
           <add name="X-XSS-Protection" value="0" />
       </customHeaders>
   </httpProtocol>
+</system.webServer>
+<location path="index.html">
+  <system.webServer>
+    <staticContent>
+      <!-- Short-lived cache for index.html -->
+      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="0.00:05:00" cacheControlCustom="public" />
+    </staticContent>
   </system.webServer>
-	<location path="index.html">
-	  <system.webServer>
-	    <staticContent>
-	      <!-- Short-lived cache for index.html -->
-	      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="0.00:05:00" cacheControlCustom="public" />
-	    </staticContent>
-	  </system.webServer>
-	</location>
+</location>
 </configuration>

--- a/browser/web.config
+++ b/browser/web.config
@@ -16,8 +16,26 @@
         <action type="Redirect" url="/products/ignite-ui-angular/getting-started" redirectType="Permanent" />
     </rule>
     </rules>
+    <outboundRules>
+      <rule name="Cache immutable files" preCondition="IsImmutable">
+        <match serverVariable="RESPONSE_Cache-Control" pattern=".*" />
+        <action type="Rewrite" value="public, max-age=31536000, immutable" />
+      </rule>
+      <preConditions>
+        <preCondition name="IsImmutable" logicalGrouping="MatchAny">
+          <add input="{REQUEST_URI}" pattern="styles-.*\.css$" />
+          <add input="{REQUEST_URI}" pattern="chunk-.*\.js$" />
+          <add input="{REQUEST_URI}" pattern="main-.*\.js$" />
+          <add input="{REQUEST_URI}" pattern="polyfills-.*\.js$" />
+          <add input="{REQUEST_URI}" pattern="/media/.*" />
+        </preCondition>
+      </preConditions>
+    </outboundRules>
   </rewrite>
   <staticContent>
+    <!-- 1 hour public cache for regular static assets -->
+    <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="0.01:00:00" cacheControlCustom="public" />
+
     <remove fileExtension=".json" />
     <remove fileExtension=".csv" />
     <remove fileExtension=".shp" />
@@ -38,4 +56,12 @@
       </customHeaders>
   </httpProtocol>
 </system.webServer>
+<location path="index.html">
+  <system.webServer>
+    <staticContent>
+      <!-- Short-lived cache for index.html -->
+      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="0.00:05:00" cacheControlCustom="public" />
+    </staticContent>
+  </system.webServer>
+</location>
 </configuration>

--- a/browser/web.config
+++ b/browser/web.config
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 <system.webServer>
+    <httpCompression directory="%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files">
+        <scheme name="gzip" dll="%Windir%\system32\inetsrv\gzip.dll" />
+        <dynamicTypes>
+            <add enabled="true" mimeType="text/*"/>
+            <add enabled="true" mimeType="message/*"/>
+            <add enabled="true" mimeType="application/javascript"/>
+            <add enabled="true" mimeType="application/json"/>
+            <add enabled="false" mimeType="*/*"/>
+        </dynamicTypes>
+        <staticTypes>
+            <add enabled="true" mimeType="text/*"/>
+            <add enabled="true" mimeType="message/*"/>
+            <add enabled="true" mimeType="application/javascript"/>
+            <add enabled="true" mimeType="application/json"/>
+            <add enabled="true" mimeType="image/svg+xml"/>
+            <add enabled="false" mimeType="*/*"/>
+        </staticTypes>
+    </httpCompression>
   <rewrite>
     <rules>
       <rule name="Angular Routes" stopProcessing="true">


### PR DESCRIPTION
Added outbound rules for caching immutable files and defined preconditions for specific file patterns.
Based on the changes that Pablo introduced in https://github.com/IgniteUI/igniteui-angular-samples/pull/3879 for the other Angular samples

**Why**:
SPA had a 1 year cache for all static files, including the index.html
This is terribly bad for updating the app because you get an older version of the app unless you force reload.
This can also lead to crashes, because the cached index.html will reference related scripts that are no longer there.

**How:**
 - New rules:
   * index.html  5 min public cache
   * Hashed files 1 year immutable public cache
     * `main-<hash>.js`
     * `chunk-<hash>.js`
     * `polyfills-<hash>.js`
     * `styles-<hash>.css`
  * Other static assets 1 hour

Additionally:
 - Enable SVG compression

These changes are already applied to 
 - angular-demos/
 - angular-demos-grid-crm/
 - angular-demos-lob/
 via the afore-mentioned PR https://github.com/IgniteUI/igniteui-angular-samples/pull/3879 

